### PR TITLE
Binary chatsounds list format

### DIFF
--- a/lua/chatsounds/cl_core.lua
+++ b/lua/chatsounds/cl_core.lua
@@ -276,8 +276,6 @@ function chatsounds.ParseList(list)
 	
 	if file_version ~= LIST_VERSION then return false, "Invalid chatsounds lists file version (" .. file_version .. ")." end
 	local writer = BYTE(0xC)
-	print("Reading chatsounds lists file, written by " .. (SOFTWARE[writer] or "[unknown]")
-		.. ", v" .. BYTE(0xD) .. "." .. BYTE(0xE) .. "." .. BYTE(0xF))
 	
 	local num_entries = BYTE(0x10)+BYTE(0x11)*0x100+BYTE(0x12)*0x10000+BYTE(0x13)*0x1000000
 	
@@ -291,7 +289,6 @@ function chatsounds.ParseList(list)
 		len_name = BYTE(pos_entry+4)+BYTE(pos_entry+5)*0x100+BYTE(pos_entry+6)*0x10000+BYTE(pos_entry+7)*0x1000000
 		
 		local name = STRING(pos_entry+8, len_name)
-		print(("Reading chatsounds entry %d of %d: "):format(num_entry, num_entries) .. name)
 		
 		pos_field = pos_entry+8+len_name
 		
@@ -303,7 +300,6 @@ function chatsounds.ParseList(list)
 			out[name] = out[name] or {}
 			table.insert(out[name], {path = path, length = duration})
 			
-			print(("Reading path %d of %d: DURATION=%f PATH="):format(num_path, num_paths, duration*1e-6) .. path)
 			pos_field = pos_field+8+len_path
 		end
 		pos_entry = pos_field

--- a/lua/chatsounds/cl_core.lua
+++ b/lua/chatsounds/cl_core.lua
@@ -298,7 +298,7 @@ function chatsounds.ParseList(list)
 			local path = STRING(pos_field+8, len_path)
 			
 			out[name] = out[name] or {}
-			table.insert(out[name], {path = path, length = duration})
+			table.insert(out[name], {path = path, length = duration*1e-3})
 			
 			pos_field = pos_field+8+len_path
 		end


### PR DESCRIPTION
This pull request introduces a new list format.

The list loader for `lists_nosend` has been modified to support the CSND format (Chatsounds List Format Specification Version 1, draft 1 (see below)).
# Comparison:
## Pure loading times (no coroutines)
### Current loader

![2016-10-02_14-43-21](https://cloud.githubusercontent.com/assets/3160048/19021382/654204fa-88c0-11e6-9368-a47d5cfdd553.png)
### Binary loader

![2016-10-02_14-41-10](https://cloud.githubusercontent.com/assets/3160048/19021384/6714382a-88c0-11e6-94ee-03f40230f51a.png)
## Loading times (within coroutines)
### Current loader

![2016-10-02_14-50-05](https://cloud.githubusercontent.com/assets/3160048/19021398/af8c34e0-88c0-11e6-9507-5a2fc50a47eb.png)
### Binary loader

![2016-10-02_14-52-52](https://cloud.githubusercontent.com/assets/3160048/19021399/b0a29c34-88c0-11e6-874c-32e86cfe52eb.png)
# Specification draft

[csnd-1draft1.txt](https://github.com/Metastruct/garrysmod-chatsounds/files/505047/csnd-1draft1.txt)
# Test data

Example data for all the currently existing sound sets can be evaluated using the [binary-lists-test-data-draft1](https://github.com/Metastruct/garrysmod-chatsounds/tree/binary-lists-test-data-draft1) branch. That branch also contains the `cl_core.lua` from this pull request, so it should be fully functional (at least in single-player; interplay with the multiplayer mode (incuding the server having its own copy) has not been tested and is irrelevant for this matter).
Note, that the files still use identical paths compared to upstream. This is to keep the changes in `cl_core.lua` at a minimum and it should be changed before putting into production.
# Pull Request

Use this pull request to comment on whether the change of the list format is a good idea. Please consider:
- Performance
- Practicality
- ?
